### PR TITLE
Less log directory inception when using MolScore

### DIFF
--- a/scripts/a2c/a2c.py
+++ b/scripts/a2c/a2c.py
@@ -77,6 +77,7 @@ def main(cfg: "DictConfig"):
                 benchmark=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_benchmark_dir=False,
                 include=cfg.molscore_include,
             )
             for task in MSB:
@@ -91,6 +92,7 @@ def main(cfg: "DictConfig"):
                 task_config=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_run_dir=False,
             )
             run_a2c(cfg, task)
     elif cfg.get("custom_task", None):

--- a/scripts/ahc/ahc.py
+++ b/scripts/ahc/ahc.py
@@ -80,6 +80,7 @@ def main(cfg: "DictConfig"):
                 benchmark=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_benchmark_dir=False,
                 include=cfg.molscore_include,
             )
             for task in MSB:
@@ -94,6 +95,7 @@ def main(cfg: "DictConfig"):
                 task_config=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_run_dir=False,
             )
             run_ahc(cfg, task)
     elif cfg.get("custom_task", None):

--- a/scripts/ppo/ppo.py
+++ b/scripts/ppo/ppo.py
@@ -83,6 +83,7 @@ def main(cfg: "DictConfig"):
                 benchmark=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_benchmark_dir=False,
                 include=cfg.molscore_include,
             )
             for task in MSB:
@@ -97,6 +98,7 @@ def main(cfg: "DictConfig"):
                 task_config=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_run_dir=False,
             )
             run_ppo(cfg, task)
     elif cfg.get("custom_task", None):

--- a/scripts/reinvent/reinvent.py
+++ b/scripts/reinvent/reinvent.py
@@ -80,6 +80,7 @@ def main(cfg: "DictConfig"):
                 benchmark=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_benchmark_dir=False,
                 include=cfg.molscore_include,
             )
             for task in MSB:
@@ -94,6 +95,7 @@ def main(cfg: "DictConfig"):
                 task_config=cfg.molscore,
                 budget=cfg.total_smiles,
                 output_dir=os.path.abspath(save_dir),
+                add_run_dir=False,
             )
             run_reinvent(cfg, task)
     elif cfg.get("custom_task", None):


### PR DESCRIPTION
MolScore logs are now collapsed into acegen log directory.

Needs latest version of MolScore on pip with `pip install molscore --upgrade`