### PR TITLE
Curriculum

### DIFF
--- a/scripts/a2c/a2c.py
+++ b/scripts/a2c/a2c.py
@@ -77,7 +77,7 @@ def main(cfg: "DictConfig"):
             yaml.dump(cfg_dict, yaml_file, default_flow_style=False)
 
         # Define training task and run
-        if cfg.get("molscore", None):
+        if cfg.get("molscore_task", None):
 
             if not _has_molscore:
                 raise RuntimeError(
@@ -85,31 +85,45 @@ def main(cfg: "DictConfig"):
                     "To install MolScore, use: `pip install MolScore`"
                 ) from MOLSCORE_ERR
 
-            if cfg.molscore in MolScoreBenchmark.presets:
-                MSB = MolScoreBenchmark(
-                    model_name=cfg.agent_name,
-                    model_parameters=dict(cfg),
-                    benchmark=cfg.molscore,
-                    budget=cfg.total_smiles,
-                    output_dir=os.path.abspath(save_dir),
-                    add_benchmark_dir=False,
-                    include=cfg.molscore_include,
-                )
-                for task in MSB:
-                    run_a2c(cfg, task)
-            else:
+            if cfg.molscore_mode == "single":
                 # Save molscore output. Also redirect output to save_dir
-                cfg.molscore = shutil.copy(cfg.molscore, save_dir)
-                data = json.load(open(cfg.molscore, "r"))
-                json.dump(data, open(cfg.molscore, "w"), indent=4)
+                cfg.molscore_task = shutil.copy(cfg.molscore_task, save_dir)
+                data = json.load(open(cfg.molscore_task, "r"))
+                json.dump(data, open(cfg.molscore_task, "w"), indent=4)
                 task = MolScore(
                     model_name=cfg.agent_name,
-                    task_config=cfg.molscore,
+                    task_config=cfg.molscore_task,
                     budget=cfg.total_smiles,
                     output_dir=os.path.abspath(save_dir),
                     add_run_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
                 )
                 run_a2c(cfg, task)
+
+            if cfg.molscore_mode == "benchmark":
+                MSB = MolScoreBenchmark(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    add_benchmark_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                for task in MSB:
+                    run_a2c(cfg, task)
+
+            if cfg.molscore_mode == "curriculum":
+                task = MolScoreCurriculum(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                run_a2c(cfg, task)
+
         elif cfg.get("custom_task", None):
             if cfg.custom_task not in custom_scoring_functions:
                 register_custom_scoring_function(cfg.custom_task, cfg.custom_task)
@@ -120,6 +134,7 @@ def main(cfg: "DictConfig"):
                 output_dir=save_dir,
             )
             run_a2c(cfg, task)
+
         else:
             raise ValueError("No scoring function specified.")
 

--- a/scripts/a2c/config_denovo.yaml
+++ b/scripts/a2c/config_denovo.yaml
@@ -10,8 +10,10 @@ num_envs: 16 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Albuterol_similarity"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Albuterol_similarity"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/a2c/config_fragment.yaml
+++ b/scripts/a2c/config_fragment.yaml
@@ -10,8 +10,10 @@ num_envs: 16 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Celecoxxib_rediscovery"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Celecoxxib_rediscovery"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/a2c/config_scaffold.yaml
+++ b/scripts/a2c/config_scaffold.yaml
@@ -10,8 +10,10 @@ num_envs: 16 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: LibINVENT_Exp1
-molscore_include: ["DRD2_SelRF_SubFilt_DF"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: LibINVENT_Exp1 # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["DRD2_SelRF_SubFilt_DF"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/ahc/ahc.py
+++ b/scripts/ahc/ahc.py
@@ -79,7 +79,7 @@ def main(cfg: "DictConfig"):
             yaml.dump(cfg_dict, yaml_file, default_flow_style=False)
 
         # Define training task and run
-        if cfg.get("molscore", None):
+        if cfg.get("molscore_task", None):
 
             if not _has_molscore:
                 raise RuntimeError(
@@ -87,31 +87,45 @@ def main(cfg: "DictConfig"):
                     "To install MolScore, use: `pip install MolScore`"
                 ) from MOLSCORE_ERR
 
-            if cfg.molscore in MolScoreBenchmark.presets:
-                MSB = MolScoreBenchmark(
-                    model_name=cfg.agent_name,
-                    model_parameters=dict(cfg),
-                    benchmark=cfg.molscore,
-                    budget=cfg.total_smiles,
-                    output_dir=os.path.abspath(save_dir),
-                    add_benchmark_dir=False,
-                    include=cfg.molscore_include,
-                )
-                for task in MSB:
-                    run_ahc(cfg, task)
-            else:
+            if cfg.molscore_mode == "single":
                 # Save molscore output. Also redirect output to save_dir
-                cfg.molscore = shutil.copy(cfg.molscore, save_dir)
-                data = json.load(open(cfg.molscore, "r"))
-                json.dump(data, open(cfg.molscore, "w"), indent=4)
+                cfg.molscore_task = shutil.copy(cfg.molscore_task, save_dir)
+                data = json.load(open(cfg.molscore_task, "r"))
+                json.dump(data, open(cfg.molscore_task, "w"), indent=4)
                 task = MolScore(
                     model_name=cfg.agent_name,
-                    task_config=cfg.molscore,
+                    task_config=cfg.molscore_task,
                     budget=cfg.total_smiles,
                     output_dir=os.path.abspath(save_dir),
                     add_run_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
                 )
                 run_ahc(cfg, task)
+
+            if cfg.molscore_mode == "benchmark":
+                MSB = MolScoreBenchmark(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    add_benchmark_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                for task in MSB:
+                    run_a2c(cfg, task)
+
+            if cfg.molscore_mode == "curriculum":
+                task = MolScoreCurriculum(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                run_ahc(cfg, task)
+
         elif cfg.get("custom_task", None):
             if cfg.custom_task not in custom_scoring_functions:
                 register_custom_scoring_function(cfg.custom_task, cfg.custom_task)
@@ -122,6 +136,7 @@ def main(cfg: "DictConfig"):
                 output_dir=save_dir,
             )
             run_ahc(cfg, task)
+
         else:
             raise ValueError("No scoring function specified.")
 

--- a/scripts/ahc/config_denovo.yaml
+++ b/scripts/ahc/config_denovo.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Albuterol_similarity"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Albuterol_similarity"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/ahc/config_fragment.yaml
+++ b/scripts/ahc/config_fragment.yaml
@@ -10,15 +10,17 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Celecoxxib_rediscovery"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Celecoxxib_rediscovery"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration
 promptsmiles: c1(C)ccc(*)cc1.NS(=O)(=O)(*)
 promptsmiles_optimize: True
 promptsmiles_shuffle: True
-promptsmiles_multi: True
+promptsmiles_multi: False
 
 # Model architecture
 model: gru # gru, lstm, or gpt2

--- a/scripts/ahc/config_scaffold.yaml
+++ b/scripts/ahc/config_scaffold.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: LibINVENT_Exp1
-molscore_include: ["DRD2_SelRF_SubFilt_DF"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: LibINVENT_Exp1 # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["DRD2_SelRF_SubFilt_DF"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/dpo/config_denovo.yaml
+++ b/scripts/dpo/config_denovo.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 20_000 # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Albuterol_similarity"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Albuterol_similarity"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/dpo/config_fragment.yaml
+++ b/scripts/dpo/config_fragment.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 20_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Celecoxxib_rediscovery"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Celecoxxib_rediscovery"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/dpo/config_scaffold.yaml
+++ b/scripts/dpo/config_scaffold.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 20_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: LibINVENT_Exp1
-molscore_include: ["DRD2_SelRF_SubFilt_DF"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: LibINVENT_Exp1 # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["DRD2_SelRF_SubFilt_DF"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/dpo/dpo.py
+++ b/scripts/dpo/dpo.py
@@ -71,7 +71,7 @@ def main(cfg: "DictConfig"):
             yaml.dump(cfg_dict, yaml_file, default_flow_style=False)
 
         # Define training task and run
-        if cfg.get("molscore", None):
+        if cfg.get("molscore_task", None):
 
             if not _has_molscore:
                 raise RuntimeError(
@@ -79,31 +79,45 @@ def main(cfg: "DictConfig"):
                     "To install MolScore, use: `pip install MolScore`"
                 ) from MOLSCORE_ERR
 
-            if cfg.molscore in MolScoreBenchmark.presets:
-                MSB = MolScoreBenchmark(
-                    model_name=cfg.agent_name,
-                    model_parameters=dict(cfg),
-                    benchmark=cfg.molscore,
-                    budget=cfg.total_smiles,
-                    output_dir=os.path.abspath(save_dir),
-                    add_benchmark_dir=False,
-                    include=cfg.molscore_include,
-                )
-                for task in MSB:
-                    run_dpo(cfg, task)
-            else:
+            if cfg.molscore_mode == "single":
                 # Save molscore output. Also redirect output to save_dir
-                cfg.molscore = shutil.copy(cfg.molscore, save_dir)
-                data = json.load(open(cfg.molscore, "r"))
-                json.dump(data, open(cfg.molscore, "w"), indent=4)
+                cfg.molscore_task = shutil.copy(cfg.molscore_task, save_dir)
+                data = json.load(open(cfg.molscore_task, "r"))
+                json.dump(data, open(cfg.molscore_task, "w"), indent=4)
                 task = MolScore(
                     model_name=cfg.agent_name,
-                    task_config=cfg.molscore,
+                    task_config=cfg.molscore_task,
                     budget=cfg.total_smiles,
                     output_dir=os.path.abspath(save_dir),
                     add_run_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
                 )
                 run_dpo(cfg, task)
+
+            if cfg.molscore_mode == "benchmark":
+                MSB = MolScoreBenchmark(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    add_benchmark_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                for task in MSB:
+                    run_dpo(cfg, task)
+
+            if cfg.molscore_mode == "curriculum":
+                task = MolScoreCurriculum(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                run_dpo(cfg, task)
+
         elif cfg.get("custom_task", None):
             if cfg.custom_task not in custom_scoring_functions:
                 register_custom_scoring_function(cfg.custom_task, cfg.custom_task)
@@ -114,6 +128,7 @@ def main(cfg: "DictConfig"):
                 output_dir=save_dir,
             )
             run_dpo(cfg, task)
+
         else:
             raise ValueError("No scoring function specified.")
 

--- a/scripts/ppo/config_denovo.yaml
+++ b/scripts/ppo/config_denovo.yaml
@@ -10,8 +10,10 @@ num_envs: 64 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Albuterol_similarity"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Albuterol_similarity"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/ppo/config_fragment.yaml
+++ b/scripts/ppo/config_fragment.yaml
@@ -10,8 +10,10 @@ num_envs: 64 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Celecoxxib_rediscovery"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Celecoxxib_rediscovery"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/ppo/config_scaffold.yaml
+++ b/scripts/ppo/config_scaffold.yaml
@@ -10,8 +10,10 @@ num_envs: 64 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: LibINVENT_Exp1
-molscore_include: ["DRD2_SelRF_SubFilt_DF"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: LibINVENT_Exp1 # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["DRD2_SelRF_SubFilt_DF"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/ppo/ppo.py
+++ b/scripts/ppo/ppo.py
@@ -82,7 +82,7 @@ def main(cfg: "DictConfig"):
             yaml.dump(cfg_dict, yaml_file, default_flow_style=False)
 
         # Define training task and run
-        if cfg.get("molscore", None):
+        if cfg.get("molscore_task", None):
 
             if not _has_molscore:
                 raise RuntimeError(
@@ -90,31 +90,45 @@ def main(cfg: "DictConfig"):
                     "To install MolScore, use: `pip install MolScore`"
                 ) from MOLSCORE_ERR
 
-            if cfg.molscore in MolScoreBenchmark.presets:
-                MSB = MolScoreBenchmark(
-                    model_name=cfg.agent_name,
-                    model_parameters=dict(cfg),
-                    benchmark=cfg.molscore,
-                    budget=cfg.total_smiles,
-                    output_dir=os.path.abspath(save_dir),
-                    add_benchmark_dir=False,
-                    include=cfg.molscore_include,
-                )
-                for task in MSB:
-                    run_ppo(cfg, task)
-            else:
+            if cfg.molscore_mode == "single":
                 # Save molscore output. Also redirect output to save_dir
-                cfg.molscore = shutil.copy(cfg.molscore, save_dir)
-                data = json.load(open(cfg.molscore, "r"))
-                json.dump(data, open(cfg.molscore, "w"), indent=4)
+                cfg.molscore_task = shutil.copy(cfg.molscore_task, save_dir)
+                data = json.load(open(cfg.molscore_task, "r"))
+                json.dump(data, open(cfg.molscore_task, "w"), indent=4)
                 task = MolScore(
                     model_name=cfg.agent_name,
-                    task_config=cfg.molscore,
+                    task_config=cfg.molscore_task,
                     budget=cfg.total_smiles,
                     output_dir=os.path.abspath(save_dir),
                     add_run_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
                 )
                 run_ppo(cfg, task)
+
+            if cfg.molscore_mode == "benchmark":
+                MSB = MolScoreBenchmark(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    add_benchmark_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                for task in MSB:
+                    run_ppo(cfg, task)
+
+            if cfg.molscore_mode == "curriculum":
+                task = MolScoreCurriculum(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                run_ppo(cfg, task)
+
         elif cfg.get("custom_task", None):
             if cfg.custom_task not in custom_scoring_functions:
                 register_custom_scoring_function(cfg.custom_task, cfg.custom_task)
@@ -125,6 +139,7 @@ def main(cfg: "DictConfig"):
                 output_dir=save_dir,
             )
             run_ppo(cfg, task)
+
         else:
             raise ValueError("No scoring function specified.")
 

--- a/scripts/reinforce/config_denovo.yaml
+++ b/scripts/reinforce/config_denovo.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000 # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Albuterol_similarity"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Albuterol_similarity"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/reinforce/config_fragment.yaml
+++ b/scripts/reinforce/config_fragment.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Celecoxxib_rediscovery"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Celecoxxib_rediscovery"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/reinforce/config_scaffold.yaml
+++ b/scripts/reinforce/config_scaffold.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: LibINVENT_Exp1
-molscore_include: ["DRD2_SelRF_SubFilt_DF"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: LibINVENT_Exp1 # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["DRD2_SelRF_SubFilt_DF"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/reinvent/config_denovo.yaml
+++ b/scripts/reinvent/config_denovo.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Albuterol_similarity"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Albuterol_similarity"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/reinvent/config_fragment.yaml
+++ b/scripts/reinvent/config_fragment.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: MolOpt
-molscore_include: ["Celecoxxib_rediscovery"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: MolOpt # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["Celecoxxib_rediscovery"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/reinvent/config_scaffold.yaml
+++ b/scripts/reinvent/config_scaffold.yaml
@@ -10,8 +10,10 @@ num_envs: 128 # Number of smiles to generate in parallel
 total_smiles: 10_000  # Total number of smiles to generate
 
 # Scoring function
-molscore: LibINVENT_Exp1
-molscore_include: ["DRD2_SelRF_SubFilt_DF"]
+molscore_mode: benchmark # single, benchmark, or curriculum
+molscore_task: LibINVENT_Exp1 # task configuration (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: ["DRD2_SelRF_SubFilt_DF"]
 custom_task: null # Requires molscore to be set to null
 
 # Promptsmiles configuration

--- a/scripts/reinvent/reinvent.py
+++ b/scripts/reinvent/reinvent.py
@@ -79,7 +79,7 @@ def main(cfg: "DictConfig"):
             yaml.dump(cfg_dict, yaml_file, default_flow_style=False)
 
         # Define training task and run
-        if cfg.get("molscore", None):
+        if cfg.get("molscore_task", None):
 
             if not _has_molscore:
                 raise RuntimeError(
@@ -87,31 +87,45 @@ def main(cfg: "DictConfig"):
                     "To install MolScore, use: `pip install MolScore`"
                 ) from MOLSCORE_ERR
 
-            if cfg.molscore in MolScoreBenchmark.presets:
-                MSB = MolScoreBenchmark(
-                    model_name=cfg.agent_name,
-                    model_parameters=dict(cfg),
-                    benchmark=cfg.molscore,
-                    budget=cfg.total_smiles,
-                    output_dir=os.path.abspath(save_dir),
-                    add_benchmark_dir=False,
-                    include=cfg.molscore_include,
-                )
-                for task in MSB:
-                    run_reinvent(cfg, task)
-            else:
+            if cfg.molscore_mode == "single":
                 # Save molscore output. Also redirect output to save_dir
-                cfg.molscore = shutil.copy(cfg.molscore, save_dir)
-                data = json.load(open(cfg.molscore, "r"))
-                json.dump(data, open(cfg.molscore, "w"), indent=4)
+                cfg.molscore_task = shutil.copy(cfg.molscore_task, save_dir)
+                data = json.load(open(cfg.molscore_task, "r"))
+                json.dump(data, open(cfg.molscore_task, "w"), indent=4)
                 task = MolScore(
                     model_name=cfg.agent_name,
-                    task_config=cfg.molscore,
+                    task_config=cfg.molscore_task,
                     budget=cfg.total_smiles,
                     output_dir=os.path.abspath(save_dir),
                     add_run_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
                 )
                 run_reinvent(cfg, task)
+
+            if cfg.molscore_mode == "benchmark":
+                MSB = MolScoreBenchmark(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    add_benchmark_dir=False,
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                for task in MSB:
+                    run_reinvent(cfg, task)
+
+            if cfg.molscore_mode == "curriculum":
+                task = MolScoreCurriculum(
+                    model_name=cfg.agent_name,
+                    model_parameters=dict(cfg),
+                    benchmark=cfg.molscore_task,
+                    budget=cfg.total_smiles,
+                    output_dir=os.path.abspath(save_dir),
+                    **cfg.get("molscore_kwargs", {}),
+                )
+                run_reinvent(cfg, task)
+
         elif cfg.get("custom_task", None):
             if cfg.custom_task not in custom_scoring_functions:
                 register_custom_scoring_function(cfg.custom_task, cfg.custom_task)
@@ -122,6 +136,7 @@ def main(cfg: "DictConfig"):
                 output_dir=save_dir,
             )
             run_reinvent(cfg, task)
+
         else:
             raise ValueError("No scoring function specified.")
 

--- a/scripts/sac/pretrain_sac.py
+++ b/scripts/sac/pretrain_sac.py
@@ -345,9 +345,8 @@ def main(cfg: "DictConfig"):
                     "train/reward": episode_rewards.mean().item(),
                     "train/min_reward": episode_rewards.min().item(),
                     "train/max_reward": episode_rewards.max().item(),
-                    "train/episode_length": episode_length.sum().item() / len(
-                        episode_length
-                    ),
+                    "train/episode_length": episode_length.sum().item()
+                    / len(episode_length),
                 }
             )
             if logger:

--- a/scripts/sac/sac.py
+++ b/scripts/sac/sac.py
@@ -345,9 +345,8 @@ def main(cfg: "DictConfig"):
                     "train/reward": episode_rewards.mean().item(),
                     "train/min_reward": episode_rewards.min().item(),
                     "train/max_reward": episode_rewards.max().item(),
-                    "train/episode_length": episode_length.sum().item() / len(
-                        episode_length
-                    ),
+                    "train/episode_length": episode_length.sum().item()
+                    / len(episode_length),
                 }
             )
             if logger:

--- a/tutorials/adding_custom_scoring_function.md
+++ b/tutorials/adding_custom_scoring_function.md
@@ -65,8 +65,8 @@ For that, we can provide the path to our factory to the config parameter `custom
 
 ```yaml
 ...
-molscore: null
-molscore_include: null
+molscore_mode: null
+molscore_task: null
 custom_task: myproject.my_scoring_funcions.QED
 ...
 ```

--- a/tutorials/breaking_down_configuration_files.md
+++ b/tutorials/breaking_down_configuration_files.md
@@ -67,7 +67,7 @@ This section is also common to all scripts. ACEGEN uses [molscore](https://githu
 ```yaml
 # Scoring function
 molscore_mode: single # single (run a single objective), benchmark (run multiple), or curriculum (run a sequence)
-molscore_task: # task configuration path (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_task: null # task configuration path (JSON), benchmark (preset only), or curriculum task (preset only)
 molscore_kwargs:
   include: [] # Allows to define only a subset of the benchmark scoring function (e.g. ["Albuterol_similarity"])
   # Other available kwargs

--- a/tutorials/breaking_down_configuration_files.md
+++ b/tutorials/breaking_down_configuration_files.md
@@ -66,8 +66,14 @@ This section is also common to all scripts. ACEGEN uses [molscore](https://githu
 
 ```yaml
 # Scoring function
-molscore: MolOpt # All available benchmarks can be found [here][https://github.com/MorganCThomas/MolScore/tree/develop/molscore/configs]
-molscore_include: null # Allows to define only a subset of the benchmark scoring function (e.g. ["Albuterol_similarity"])
+molscore_mode: single # single (run a single objective), benchmark (run multiple), or curriculum (run a sequence)
+molscore_task: # task configuration path (JSON), benchmark (preset only), or curriculum task (preset only)
+molscore_kwargs:
+  include: [] # Allows to define only a subset of the benchmark scoring function (e.g. ["Albuterol_similarity"])
+  # Other available kwargs
+  custom_benchmark: null # Path to a directory containing a list of benchmark configuration files or a sequence of objectives for curriculum learning
+  custom_tasks: []  # Individual configuration file paths (JSONs) to be added to the benchmark/curriculum
+  exclude: []  # Names of configuration files to exclude
 custom_task: null # Requires molscore to be set to null.
 ```
 


### PR DESCRIPTION
Addition of new curriculum learning in MolScore==1.7

New format of the configuration files, therefore, this is a breaking update if trying to use an old configuration format.
- New handling of MolScore arguments
- New configuration formats, now explicit specification of `molscore_mode` as single, benchmark or curriculum
- New documentation