### PR TITLE
fix acegen to tested versions of torchrl and tensordict

### DIFF
--- a/.github/unittest/install_dependencies.sh
+++ b/.github/unittest/install_dependencies.sh
@@ -1,10 +1,12 @@
 # Upgrade pip
 python -m pip install --upgrade pip
 
-# Install dependencies
-python -m pip install flake8 pytest pytest-cov hydra-core tqdm
+# Install required dependencies
 python -m pip install torch torchvision
-python -m pip install transformers promptsmiles torchrl rdkit==2023.3.3 MolScore
+python -m pip install -r acegen-open/requirements.txt
+
+# Install additional dependencies
+python -m pip install transformers promptsmiles MolScore
 python -m pip install deepsmiles
 python -m pip install selfies
 python -m pip install smi2sdf

--- a/.github/unittest/install_dependencies.sh
+++ b/.github/unittest/install_dependencies.sh
@@ -2,6 +2,7 @@
 python -m pip install --upgrade pip
 
 # Install required dependencies
+python -m pip install flake8 pytest pytest-cov hydra-core tqdm
 python -m pip install torch torchvision
 python -m pip install -r acegen-open/requirements.txt
 

--- a/.github/unittest/install_dependencies.sh
+++ b/.github/unittest/install_dependencies.sh
@@ -4,7 +4,8 @@ python -m pip install --upgrade pip
 # Install required dependencies
 python -m pip install flake8 pytest pytest-cov hydra-core tqdm
 python -m pip install torch torchvision
-python -m pip install -r acegen-open/requirements.txt
+python -m pip install git+https://github.com/pytorch/rl.git@767a877a0a93d41a9b7935598da0ded4c984904f
+python -m pip install git+https://github.com/pytorch/tensordict.git@3812ca62d0d5db7d337592d99934e32a3d2b4bfd
 
 # Install additional dependencies
 python -m pip install transformers promptsmiles MolScore

--- a/README.md
+++ b/README.md
@@ -78,14 +78,18 @@ conda create -n acegen python=3.10 -y
 conda activate acegen
 ```
 
-To install the required dependencies run the following commands. Replace `cu121` with your appropriate CUDA version (e.g., `cu118`, `cu117`, `cu102`).
+First install `torch` replacing `cu121` with your appropriate CUDA version (e.g., `cu118`, `cu117`, `cu102`).
 
 ```bash
 pip3 install torch torchvision  --index-url https://download.pytorch.org/whl/cu121
-pip3 install flake8 pytest pytest-cov hydra-core tqdm wandb
-pip3 install torchrl
 ```
 
+To install general requirements and the acegen stable versions of `torchrl` and `tensordict` run the following command.
+
+```bash
+pip3 install -r requirements.txt
+``` 
+[Optional] You can install the latest versions by running `pip3 install torchrl --upgrade` but they may not have been tested. 
 
   </details>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+# General dependencies
+flake8
+pytest
+pytest-cov
+hydra-core
+tqdm
+wandb
+rdkit>=2023.3.3
+
+# TorchRL and Tensordict
+git+https://github.com/pytorch/rl.git@767a877a0a93d41a9b7935598da0ded4c984904f
+git+https://github.com/pytorch/tensordict.git@3812ca62d0d5db7d337592d99934e32a3d2b4bfd

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -18,7 +18,7 @@ except ImportError:
 
 skip_if_promptsmiles_not_available = pytest.mark.skipif(
     not promptsmiles_available,
-    reason="prompsmiles library is not available, skipping this test",
+    reason="promptsmiles library is not available, skipping this test",
 )
 
 


### PR DESCRIPTION
- Moved requirements in README to requirements.txt
- RDKit is now a required dependency otherwise tests fail
- TorchRL and Tensordict fixed to tested versions using git commit hashes