### PR TITLE
Fix torchrl v0.11 PPO/A2C loss kwargs

### DIFF
--- a/scripts/a2c/a2c.py
+++ b/scripts/a2c/a2c.py
@@ -164,8 +164,8 @@ def run_a2c(cfg, task):
     loss_module = A2CLoss(
         actor_network=actor_training,
         critic_network=critic_training,
-        critic_coef=cfg.critic_coef,
-        entropy_coef=cfg.entropy_coef,
+        critic_coeff=cfg.critic_coef,
+        entropy_coeff=cfg.entropy_coef,
         loss_critic_type="l2",
     )
 

--- a/scripts/ppo/ppo.py
+++ b/scripts/ppo/ppo.py
@@ -165,8 +165,8 @@ def run_ppo(cfg, task):
     loss_module = ClipPPOLoss(
         actor=actor_training,
         critic=critic_training,
-        critic_coef=cfg.critic_coef,
-        entropy_coef=cfg.entropy_coef,
+        critic_coeff=cfg.critic_coef,
+        entropy_coeff=cfg.entropy_coef,
         clip_epsilon=cfg.ppo_clip,
         loss_critic_type="l2",
         normalize_advantage=True,


### PR DESCRIPTION
Update torchrl loss kwargs for v0.11:
critic_coef → critic_coeff
entropy_coef → entropy_coeff

This only occurs in `scripts/ppo/ppo.py` and `scripts/a2c/a2c.py`.

Keep config names unchanged (cfg.critic_coef, cfg.entropy_coef, and other _coefs)